### PR TITLE
Fix crash when --suppress_output_file_sequence is set

### DIFF
--- a/Hitrava.py
+++ b/Hitrava.py
@@ -1884,6 +1884,8 @@ def main():
 
     tcx_xml_schema = None if not args.validate_xml else _init_tcx_xml_schema()
 
+    output_file_suffix = ""
+    
     if args.file:
         if args.sport:
             hi_file = HiTrackFile(args.file, args.sport)


### PR DESCRIPTION
Ensure `output_file_suffix` is defined, even if `--suppress_output_file_sequence` is set.

Thanks for this tool :-).

Any chance you're considering publishing it to pypi?

Cheers,

Mark