### PR TITLE
Version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project are documented in this file. 
 
 ## Release Notes
+### Version 6.0.0 (build 2412.2801)
+#### New features and changes
+- Added support for the new Huawei 2025 ZIP export format for users on Windows or Linux.
+- Bumped recommended Python version to 3.12.1 or higher.
+  Older versions might still work, but were / are not actively being tested nor maintained / supported.
+- Did some minor code cleanup and changed code deprecations.
+
+#### Known limitations
+- This version has no support for the new Huawei 2025 ZIP export format for macOS users  
+  (I do not have access to a macOS system to properly develop / test the unzip process).
+
 ### Version 5.1.2 (build 2308.2601)
 #### Solved Issues
 - Conversion failed for open water swimming activities in conjunction with distance normalization. Closes #74.

--- a/Hitrava.py
+++ b/Hitrava.py
@@ -1158,7 +1158,6 @@ class HiZip:
 
         if platform.system() in ['Windows', 'Linux']:
             unzip_cmd = ('7za', 'e', '-aoa', '-o%s' % output_dir, '-bb0', '-bse0', '-bsp2', '-p%s' % password, '-sccUTF-8', '%s' % zip_filename, '--', '%s' % zip_json_filenames)
-            print(unzip_cmd)
         elif platform.system() == 'Darwin':
             message = f'Encrypted ZIP files in Huawei 2025 format not supported on platform {platform.system()}',
             logging.getLogger(PROGRAM_NAME).error(message)

--- a/Hitrava.py
+++ b/Hitrava.py
@@ -2,7 +2,7 @@
 
 # Hitrava.py
 # Original Work Copyright (c) 2019 Ari Cooper-Davis / Christoph Vanthuyne - github.com/aricooperdavis/Huawei-TCX-Converter
-# Modified Work Copyright (c) 2019-2023 Christoph Vanthuyne - https://github.com/CTHRU/Hitrava
+# Modified Work Copyright (c) 2019-2025 Christoph Vanthuyne - https://github.com/CTHRU/Hitrava
 # Released under the Non-Profit Open Software License version 3.0
 
 
@@ -28,7 +28,7 @@ import xml.etree.cElementTree as xml_et
 from datetime import datetime as dts
 from datetime import timedelta as dts_delta
 from datetime import timezone as tz
-from zipfile import ZipFile as ZipFile
+from zipfile import ZipFile
 
 # External libraries that require installation
 from typing import Optional
@@ -36,24 +36,23 @@ from typing import Optional
 try:
     import xmlschema  # (only) needed to validate the generated TCX XML.
 except:
-    sys.stderr.write('Info - External library xmlschema could not be imported.\n' +
+    sys.stderr.write('\nInfo - External library xmlschema could not be imported.\n' +
                      'It is required when using the --validate_xml argument.\n' +
                      'It can be installed using: pip install xmlschema\n')
 
-if sys.version_info < (3, 5, 1):
-    sys.stderr.write('You need Python 3.5.1 or later (you are using Python %s.%s.%s).\n' %
-                     (sys.version_info.major,
-                      sys.version_info.minor,
-                      sys.version_info.micro))
-    sys.exit(1)
+if sys.version_info < (3, 12, 1):
+    sys.stderr.write(f'\nWarning - Hitrava was developed and tested on Python 3.12.1 or later.\n'
+                     f'You are using an older Python version {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}.\n'
+                     f'Although this might work, if you experience any issues,\n'
+                     f'please try upgrading your python version to at least 3.12.1 first.\n\n')
 
 # Global Constants
 PROGRAM_NAME = 'Hitrava'
-PROGRAM_MAJOR_VERSION = '5'
-PROGRAM_MINOR_VERSION = '1'
-PROGRAM_PATCH_VERSION = '2'
-PROGRAM_MAJOR_BUILD = '2308'
-PROGRAM_MINOR_BUILD = '2601'
+PROGRAM_MAJOR_VERSION = '6'
+PROGRAM_MINOR_VERSION = '0'
+PROGRAM_PATCH_VERSION = '0'
+PROGRAM_MAJOR_BUILD = '2412'
+PROGRAM_MINOR_BUILD = '2801'
 
 OUTPUT_DIR = './output'
 GPS_TIMEOUT = dts_delta(seconds=10)
@@ -1138,58 +1137,105 @@ class HiTarBall:
 
 class HiZip:
     @staticmethod
+    def extract_json_list(zip_filename: str, output_dir: str = OUTPUT_DIR, password: str = None) -> Optional[list]:
+        _MOTION_PATH_JSON_DIR = 'Motion path detail data & description'
+
+        if not zipfile.is_zipfile(zip_filename):
+            message = f'Invalid ZIP file or ZIP file not found <{zip_filename}>'
+            logging.getLogger(PROGRAM_NAME).error(message)
+            raise Exception(message)
+
+        if not password:
+            message = f'ZIP file <{zip_filename}> is encrypted but no password is provided'
+            logging.getLogger(PROGRAM_NAME).error(message)
+            raise Exception(message)
+
+        # New 2024-12 multiple JSON file format
+        zip_json_filenames = f'{_MOTION_PATH_JSON_DIR}/*.json'
+
+        huawei_zip = zipfile.ZipFile(zip_filename)
+        huawei_json_filenames = [f'{output_dir}/{f.filename.split('/')[-1]}' for f in huawei_zip.infolist() if f.filename.startswith(_MOTION_PATH_JSON_DIR + '/') and f.filename.endswith('.json')]
+
+        if platform.system() in ['Windows', 'Linux']:
+            unzip_cmd = ('7za', 'e', '-aoa', '-o%s' % output_dir, '-bb0', '-bse0', '-bsp2', '-p%s' % password, '-sccUTF-8', '%s' % zip_filename, '--', '%s' % zip_json_filenames)
+            print(unzip_cmd)
+        elif platform.system() == 'Darwin':
+            message = f'Encrypted ZIP files in Huawei 2025 format not supported on platform {platform.system()}',
+            logging.getLogger(PROGRAM_NAME).error(message)
+            raise NotImplementedError(message)
+        else:
+            message = f'Encrypted ZIP files in Huawei 2025 format not supported on platform {platform.system()}',
+            logging.getLogger(PROGRAM_NAME).error(message)
+            raise NotImplementedError(message)
+        completed_process = subprocess.run(unzip_cmd,
+                                           universal_newlines=True,
+                                           stderr=subprocess.STDOUT,
+                                           stdout=subprocess.PIPE)
+        logging.getLogger(PROGRAM_NAME).info(completed_process.stdout)
+        if completed_process.returncode != 0:
+            message = f'Error extracting JSON files from encrypted ZIP file <{zip_filename}>. Return code was {completed_process.returncode}'
+            logging.getLogger(PROGRAM_NAME).error(message)
+            raise Exception(message)
+
+        return huawei_json_filenames
+
+
+    @staticmethod
     def extract_json(zip_filename: str, output_dir: str = OUTPUT_DIR, password: str = None):
         _MOTION_PATH_JSON_FILENAME = 'data/Motion path detail data & description/motion path detail data.json'
         _MOTION_PATH_JSON_FILENAME_ALT = 'Motion path detail data & description/motion path detail data.json'
         _WINDOWS_UNZIP_CMD = '7za x -aoa "-o%s" -bb0 -bse0 -bsp2 "-p%s" -sccUTF-8 "%s" -- "%s"'
-        _MACOS_UNZIP_CMD = 'unzip %s -P %s -d %s %s'
+        _MACOS_UNZIP_CMD = 'unzip %s -P %s -d %s %s '
 
-        if zipfile.is_zipfile(zip_filename):
-            if password is not None:
-                zip_json_filename = _MOTION_PATH_JSON_FILENAME_ALT
-                if platform.system() == 'Windows':
-                    unzip_cmd = _WINDOWS_UNZIP_CMD % (output_dir, password, zip_filename, zip_json_filename)
-                elif platform.system() == 'Darwin':
-                    unzip_cmd = _MACOS_UNZIP_CMD % (zip_filename, password, output_dir, zip_json_filename)
-                else:
-                    logging.getLogger(PROGRAM_NAME).error('Encrypted ZIP files not supported on platform %s',
-                                                          platform.system())
-                    raise NotImplementedError('Encrypted ZIP files not supported on platform %s', platform.system())
-                completed_process = subprocess.run(unzip_cmd,
-                                                   universal_newlines=True,
-                                                   stderr=subprocess.STDOUT,
-                                                   stdout=subprocess.PIPE)
-                logging.getLogger(PROGRAM_NAME).info(completed_process.stdout)
-                if completed_process.returncode != 0:
-                    logging.getLogger(PROGRAM_NAME).error('Error extracting JSON file <%s> from encrypted ZIP file <%s>. Return code was %s',
-                                                          zip_json_filename, zip_filename, completed_process.returncode)
-                    raise Exception('Error extracting JSON file <%s> from encrypted ZIP file <%s>. Return code was %s',
-                                    zip_json_filename, zip_filename, completed_process.returncode)
-            else:
-                with ZipFile(zip_filename, 'r', True) as hi_zip:
-                    if _MOTION_PATH_JSON_FILENAME in hi_zip.namelist():
-                        zip_json_filename = _MOTION_PATH_JSON_FILENAME
-                    elif _MOTION_PATH_JSON_FILENAME_ALT in hi_zip.namelist():
-                        zip_json_filename = _MOTION_PATH_JSON_FILENAME_ALT
-                    else:
-                        logging.getLogger(PROGRAM_NAME).warning('Could not find JSON file <%s> in ZIP file <%s>. \
-                                                                Nothing to convert.',
-                                                                _MOTION_PATH_JSON_FILENAME, zip_filename)
-                        raise Exception('Could not find file <data/motion path detail data.json> in ZIP file <%s>. \
-                                        Nothing to convert.', zip_filename)
-
-                    try:
-                        hi_zip.extract(zip_json_filename, output_dir)
-                    except Exception as e:
-                        logging.getLogger(PROGRAM_NAME).error('Error extracting JSON file <%s> from ZIP file <%s>\n%s',
-                                                              zip_json_filename, zip_filename, e)
-                        raise Exception('Error extracting JSON file <%s> from ZIP file <%s>',
-                                        zip_json_filename, zip_filename)
-            json_filename = output_dir + '/' + zip_json_filename
-            return json_filename
-        else:
+        if not zipfile.is_zipfile(zip_filename):
             logging.getLogger(PROGRAM_NAME).error('Invalid ZIP file or ZIP file not found <%s>', zip_filename)
             raise Exception('Invalid ZIP file or ZIP file not found <%s>', zip_filename)
+
+        if password is not None:
+            # Pre 2024-06 1 JSON file format
+            zip_json_filename = _MOTION_PATH_JSON_FILENAME_ALT
+            if platform.system() == 'Windows':
+                unzip_cmd = _WINDOWS_UNZIP_CMD % (output_dir, password, zip_filename, zip_json_filename)
+            elif platform.system() == 'Darwin':
+                unzip_cmd = _MACOS_UNZIP_CMD % (zip_filename, password, output_dir, zip_json_filename)
+            else:
+                logging.getLogger(PROGRAM_NAME).error('Encrypted ZIP files not supported on platform %s',
+                                                      platform.system())
+                raise NotImplementedError('Encrypted ZIP files not supported on platform %s', platform.system())
+            completed_process = subprocess.run(unzip_cmd,
+                                               universal_newlines=True,
+                                               stderr=subprocess.STDOUT,
+                                               stdout=subprocess.PIPE)
+            logging.getLogger(PROGRAM_NAME).info(completed_process.stdout)
+            if completed_process.returncode != 0:
+                logging.getLogger(PROGRAM_NAME).error('Error extracting JSON file <%s> from encrypted ZIP file <%s>. Return code was %s',
+                                                      zip_json_filename, zip_filename, completed_process.returncode)
+                raise Exception('Error extracting JSON file <%s> from encrypted ZIP file <%s>. Return code was %s',
+                                zip_json_filename, zip_filename, completed_process.returncode)
+        else:
+            # Legacy ZIP file format without password
+            with ZipFile(zip_filename, 'r', True) as hi_zip:
+                if _MOTION_PATH_JSON_FILENAME in hi_zip.namelist():
+                    zip_json_filename = _MOTION_PATH_JSON_FILENAME
+                elif _MOTION_PATH_JSON_FILENAME_ALT in hi_zip.namelist():
+                    zip_json_filename = _MOTION_PATH_JSON_FILENAME_ALT
+                else:
+                    logging.getLogger(PROGRAM_NAME).warning('Could not find JSON file <%s> in ZIP file <%s>. \
+                                                            Nothing to convert.',
+                                                            _MOTION_PATH_JSON_FILENAME, zip_filename)
+                    raise Exception('Could not find file <data/motion path detail data.json> in ZIP file <%s>. \
+                                    Nothing to convert.', zip_filename)
+
+                try:
+                    hi_zip.extract(zip_json_filename, output_dir)
+                except Exception as e:
+                    logging.getLogger(PROGRAM_NAME).error('Error extracting JSON file <%s> from ZIP file <%s>\n%s',
+                                                          zip_json_filename, zip_filename, e)
+                    raise Exception('Error extracting JSON file <%s> from ZIP file <%s>',
+                                    zip_json_filename, zip_filename)
+
+        json_filename = output_dir + '/' + zip_json_filename
+        return json_filename
 
 
 class HiJson:
@@ -1240,7 +1286,7 @@ class HiJson:
             # for the keys). For now, remove the invalid parts using a regular expression.
             json_string = self.json_file.read()
 
-            json_string = re.sub('\"partTimeMap\"\:{(.*?)}\,', '', json_string)
+            json_string = re.sub('\"partTimeMap\":{(.*?)},', '', json_string)
 
             data = json.loads(json_string)
 
@@ -1260,16 +1306,16 @@ class HiJson:
             # data {list}
             #   0 {dict}
             #     sportType {int}
-            #     attribute {str} 'HW_EXT_TRACK_DETAIL@is<HiTrack File Data>&&HW_EXT_TRACK_SIMPLIFY@is<Other Data>
+            #     attribute {str} 'HW_EXT_TRACK_DETAIL@is<HiTrack File Data>&&HW_EXT_TRACK_SIMPLIFY@is<Other Data>'
             #   1 {dict}
             #     sportType {int}
-            #     attribute {str} 'HW_EXT_TRACK_DETAIL@is<HiTrack File Data>&&HW_EXT_TRACK_SIMPLIFY@is<Other Data>
+            #     attribute {str} 'HW_EXT_TRACK_DETAIL@is<HiTrack File Data>&&HW_EXT_TRACK_SIMPLIFY@is<Other Data>'
             n = -1
             for n, activity_dict in enumerate(data):
                 if 'recordDay' in activity_dict:
                     activity_date = dts.strptime(str(activity_dict['recordDay']), "%Y%m%d").date()
                 else:
-                    activity_date = dts.utcfromtimestamp(activity_dict['startTime'] / 1000).date()
+                    activity_date = dts.fromtimestamp(activity_dict['startTime'] / 1000, datetime.UTC).date()
 
                 if activity_date >= from_date:
                     logging.getLogger(PROGRAM_NAME).info(
@@ -1303,12 +1349,12 @@ class HiJson:
         # Create a HiTrack file from the HiTrack data
         hitrack_data = activity_dict['attribute']
         # Strip prefix and suffix from raw HiTrack data
-        hitrack_data = re.sub('HW_EXT_TRACK_DETAIL\@is', '', hitrack_data)
-        hitrack_data = re.sub('\&\&HW_EXT_TRACK_SIMPLIFY\@is(.*)', '', hitrack_data, flags=re.DOTALL)
+        hitrack_data = re.sub('HW_EXT_TRACK_DETAIL@is', '', hitrack_data)
+        hitrack_data = re.sub('&&HW_EXT_TRACK_SIMPLIFY@is(.*)', '', hitrack_data, flags=re.DOTALL)
 
         # Get additional activity detail data
         activity_detail_data = activity_dict['attribute']
-        activity_detail_data = re.sub('HW_EXT_TRACK_DETAIL\@is(.*)\&\&HW_EXT_TRACK_SIMPLIFY\@is',
+        activity_detail_data = re.sub('HW_EXT_TRACK_DETAIL@is(.*)&&HW_EXT_TRACK_SIMPLIFY@is',
                                       '', activity_detail_data, flags=re.DOTALL)
         activity_detail_dict = json.loads(activity_detail_data)
 
@@ -1320,7 +1366,7 @@ class HiJson:
                                  minutes=time_zone_minutes_offset))
 
         # Get start date and time in UTC
-        activity_start = dts.utcfromtimestamp(activity_dict['startTime'] / 1000)
+        activity_start = dts.fromtimestamp(activity_dict['startTime'] / 1000, datetime.UTC)
 
         # Save HiTrack data to HiTrack file
         hitrack_filename = "%s/HiTrack_%s" % \
@@ -1915,13 +1961,13 @@ def _convert_hitrack_timestamp(hitrack_timestamp: float, timestamp_ref: datetime
     timestamp_digits = int(math.log10(hitrack_timestamp))
     if timestamp_ref is not None and hitrack_timestamp < 604800:   # Assume activity not longer than a week.
         # Relative seconds from timestamp reference
-        return dts.utcfromtimestamp((timestamp_ref + dts_delta(seconds=hitrack_timestamp)).timestamp())
+        return dts.fromtimestamp((timestamp_ref + dts_delta(seconds=hitrack_timestamp)).timestamp(), datetime.UTC)
     elif timestamp_digits == 9:
         # Absolute epoch timestamp
-        return dts.utcfromtimestamp(int(hitrack_timestamp))
+        return dts.fromtimestamp(int(hitrack_timestamp), datetime.UTC)
 
     divisor = 10 ** (timestamp_digits - 9) if timestamp_digits > 9 else 0.1 ** (9 - timestamp_digits)
-    return dts.utcfromtimestamp(int(hitrack_timestamp / divisor))
+    return dts.fromtimestamp(int(hitrack_timestamp / divisor), datetime.UTC)
 
 
 def _get_tz_aware_datetime(naive_datetime: dts, time_zone: tz):
@@ -1972,8 +2018,8 @@ def _init_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     json_group = parser.add_argument_group('JSON options')
     json_group.add_argument('-z', '--zip', help='The filename of the Huawei Cloud ZIP file containing \
-                                                 the JSON file with the motion path detail data to convert. \
-                                                 The JSON file will be extracted to the directory in the --output_dir \
+                                                 the JSON file(s) with the motion path detail data to convert. \
+                                                 The JSON file(s) will be extracted to the directory in the --output_dir \
                                                  argument and conversion will be performed.')
 
     json_group.add_argument('-p', '--password', help='The password of the encrypted Huawei Cloud ZIP file. \
@@ -2086,7 +2132,7 @@ def main():
         _init_logging()
 
     args_string = str(sys.argv[1:])
-    args_string = re.sub("('--password', '\w*')|('-p', '\w*')", "'--password', '********'", args_string)
+    args_string = re.sub("('--password', 'w*')|('-p', 'w*')", "'--password', '********'", args_string)
     logging.getLogger(PROGRAM_NAME).info("%s version %s.%s.%s (build %s.%s) started with arguments %s",
                                          PROGRAM_NAME,
                                          PROGRAM_MAJOR_VERSION,
@@ -2146,24 +2192,35 @@ def main():
                 tcx_activity.save(tcx_filename)
             logging.getLogger(PROGRAM_NAME).info('Converted %s', hi_activity)
     elif args.json or args.zip:
+        json_filename_list = None
+        json_filename = None
         if args.zip:
-            json_filename = HiZip.extract_json(args.zip, args.output_dir, args.password)
+            # New 2024-12 Huawei ZIP file format
+            json_filename_list = HiZip.extract_json_list(args.zip, args.output_dir, args.password)
+            if not json_filename_list:
+                # Old pre 2024-06 Huawei Zip format
+                json_filename = HiZip.extract_json(args.zip, args.output_dir, args.password)
         elif args.json and zipfile.is_zipfile(args.json):
             json_filename = HiZip.extract_json(args.json, args.output_dir, args.password)
         else:
             json_filename = args.json
-        hi_json = HiJson(json_filename, args.output_dir, args.json_export)
-        hi_activity_list = hi_json.parse(args.from_date)
-        for n, hi_activity in enumerate(hi_activity_list, start=1):
-            if args.pool_length:
-                hi_activity.set_pool_length(args.pool_length)
-            if not args.tcx_use_raw_distance_data:
-                hi_activity.normalize_distances()
-            output_file_suffix = output_file_suffix_format % (n % 1000)
-            tcx_activity = TcxActivity(hi_activity, tcx_xml_schema, args.output_dir, args.output_file_prefix,
-                                       output_file_suffix, args.tcx_insert_altitude_data)
-            tcx_activity.save()
-            logging.getLogger(PROGRAM_NAME).info('Converted %s', hi_activity)
+
+        if not json_filename_list and json_filename:
+            json_filename_list = [json_filename]
+
+        for json_filename in json_filename_list:
+            hi_json = HiJson(json_filename, args.output_dir, args.json_export)
+            hi_activity_list = hi_json.parse(args.from_date)
+            for n, hi_activity in enumerate(hi_activity_list, start=1):
+                if args.pool_length:
+                    hi_activity.set_pool_length(args.pool_length)
+                if not args.tcx_use_raw_distance_data:
+                    hi_activity.normalize_distances()
+                output_file_suffix = output_file_suffix_format % (n % 1000)
+                tcx_activity = TcxActivity(hi_activity, tcx_xml_schema, args.output_dir, args.output_file_prefix,
+                                           output_file_suffix, args.tcx_insert_altitude_data)
+                tcx_activity.save()
+                logging.getLogger(PROGRAM_NAME).info('Converted %s', hi_activity)
 
 
 if __name__ == '__main__':

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 Non-Profit Open Software License 3.0 (NPOSL-3.0)
 
-Copyright (c) 2019-2023 Christoph Vanthuyne
+Copyright (c) 2019-2025 Christoph Vanthuyne
 
 This Non-Profit Open Software License ("Non-Profit OSL") version 3.0 (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following licensing notice adjacent to the copyright notice for the Original Work:
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@
 [![Buy me a coffee][shield buymeacoffee]][buymeacoffee]
 
 ---------
-## IMPORTANT NOTICE
-As of July, 2024, there are breaking changes to the Huawei export format.
-Unfortunately, these changes also involve the raw data on which Hitrava relied to create your exported activities, to have disappeared.
-This will be apparent by Hitrava returning a message that decoding and decompressing of the ZIP file failed.
-I regret to inform you that Hitrava probably will not be able to export your activities in the future. The program is still available for now for users who want to convert any export files in the original export format.
+## Hitrava is Back (28-Dec-2024)
+  
+### Background
+In July, 2024, there were breaking changes to the Huawei export format.  
+These changes involved the raw data on which Hitrava relied to create your exported activities, to have disappeared.    
+
+### Thank you, Davide
+Thanks to community member [Davide Pacifico](https://github.com/jimiend) who took the
+effort to sort out the [issue](https://github.com/CTHRU/Hitrava/issues/78) with Huawei and GDPR,
+we can confirm that the data is back, be it packed in a different way then before.  
+The latest version 6 update now supports the new format to give you your trusted Huawei Health activity converter back. 
 
 ----------
 ## Introduction
@@ -23,9 +29,8 @@ directly uploaded to [`Strava`](https://strava.com).
 ### Hitrava Web
 [![Hitrava](images/Hitrava_Web_Screenshot_Small.png)](https://cthru.hopto.org/hitrava-web)  
   
-**22-Apr-2024: [Hitrava Web](https://cthru.hopto.org/hitrava-web) just got updated!**  
-Though it is still an alpha release, it is the last step before a fully functional beta version.  
-The cthru website also got a major update and upgrade and is now always available.  
+**28-Dec-2024: [Hitrava Web](https://cthru.hopto.org/hitrava-web) is not yet available for the new Huawei 2025 ZIP export format.  
+I am working on a solution in the coming weeks.**  
 If you prefer on-line conversion in a web app with GUI over a script, 
 you can give it a try on [https://cthru.hopto.org](https://cthru.hopto.org/hitrava-web).
 
@@ -37,13 +42,14 @@ you can give it a try on [https://cthru.hopto.org](https://cthru.hopto.org/hitra
 - [Features](#features)  
 - [Installation](#installation)  
 - [How To Convert](#how-to-convert-your-health-activities-and-import-them-in-strava)   
-  -[Windows Users](#windows-users---encrypted-zip-conversion-procedure)  
-  -[macOS / Linux / UNIX Users](#other-operating-systems-users-macos-linux-unix)  
+  -[Windows / Linux Users](#windows-users---encrypted-zip-conversion-procedure)  
+  -[macOS Users](#other-operating-systems-users-macos)  
 - [Usage](#usage)  
     - [Command Line Arguments](#command-line-arguments-overview)  
     - [Examples](#usage-examples)
 - [Release Notes](#release-notes)  
 - [Copyright and License](#copyright-and-license)
+- [Aim for the stars](#star-history)
 
 ## Features
 - Recognizes and converts the following activity types from Huawei Health to Strava:
@@ -70,12 +76,12 @@ or fitness band should be supported, if you see the data in Huawei Health, e.g.
 ## Installation
 ### Requirements
 To use Hitrava, you need:
-- [`Python 3.7.x`](https://www.python.org/downloads/) or higher.
-    - Python 3.7.6 is the lowest recommended version (developed and tested on this version).
-    - Python 3.5.1 is the lowest minimum required version (compatibility tested on this version). 
+- [`Python 3.12.1`](https://www.python.org/downloads/) or higher.
+    - Python 3.12.1 is the lowest recommended version (developed and tested on this version).
+    - Older Python versions might still work, but were / are not actively being tested.
 - A Huawei account to request your health data.
 - 7-Zip stand-alone version to convert directly from an encrypted Huawei Health ZIP file. Currently, this method is only 
-supported on Windows operating systems.
+supported on Windows and Linux operating systems.
 
 ### Installation Procedure
 #### Step 1 - Install Python
@@ -167,15 +173,15 @@ You can now go to the Strava website to import your data.
 - Once logged in, use the **'Browse...'** button on the page and select the converted TCX files (with the _.tcx_ 
 extension, up to 25 at once) to upload. 
 
-### Other Operating Systems Users (macOS, Linux, UNIX)
+### Other Operating Systems Users (macOS)
 #### Step 1 - Request your data
 Follow the same procedure as for Windows users explained [above](#step-1---request-your-data-in-the-huawei-health-app).
 
 #### Step 2 - Download and extract your data
 - In the mail from Huawei, click on the link to download your data and follow the instructions.
-- Extract the following file from the downloaded ZIP file using an unzip tool for your operating system that supports
+- Extract the following file(s) from the downloaded ZIP file using an unzip tool for your operating system that supports
  AES encrypted ZIP files.
-  > Motion path detail data & description/motion path detail data.json
+  > Motion path detail data & description/motion path detail data{epoch datetimestamp goes here}.json
 - Put (a copy of) the extracted file in the Hitrava installation folder and rename it to HiJson.json.
 
 #### Step 3 - Convert the JSON file with Hitrava
@@ -381,6 +387,10 @@ Licensed under the Non-Profit Open Software License version 3.0 from Hitrava ver
 Read the full license information [`here`](./LICENSE.md).
 
 If you're more into a TL;DR approach, start [`here`][tldrlegal nposl3.0].
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=CTHRU/Hitrava&type=Date)](https://star-history.com/#CTHRU/Hitrava&Date)
 
 [shield nposl3.0]: https://img.shields.io/badge/license-nposl--3.0-blue
 [tldrlegal nposl3.0]: https://tldrlegal.com/license/non-profit-open-software-license-3.0-(nposl-3.0)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ For a full changelog of all versions, please look in [`CHANGELOG.md`](./CHANGELO
 ## Copyright and License
 [![nposl3.0][shield nposl3.0]][tldrlegal nposl3.0]  
 
-Copyright (c) 2019-2023 Christoph Vanthuyne
+Copyright (c) 2019-2025 Christoph Vanthuyne
 
 Licensed under the Non-Profit Open Software License version 3.0 from Hitrava version 3.1.1 onward.  
 


### PR DESCRIPTION
### Version 6.0.0 (build 2412.2801)
#### New features and changes
- Added support for the new Huawei 2025 ZIP export format for users on Windows or Linux.
- Bumped recommended Python version to 3.12.1 or higher.
  Older versions might still work, but were / are not actively being tested nor maintained / supported.
- Did some minor code cleanup and changed code deprecations.

#### Known limitations
- This version has no support for the new Huawei 2025 ZIP export format for macOS users  
  (I do not have access to a macOS system to properly develop / test the unzip process).
